### PR TITLE
Add vibration mode option

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import {
   StyleSheet, View, Text, TouchableOpacity,
-  Alert, AppState, Dimensions, ScrollView, Switch, Modal
+  Alert, AppState, Dimensions, ScrollView, Switch, Modal, Vibration
 } from 'react-native';
 import { Audio, InterruptionModeIOS, InterruptionModeAndroid } from 'expo-av';
 import CompassHeading from 'react-native-compass-heading';
@@ -102,6 +102,7 @@ export default function App() {
   const [calibrationOffset, setCalibrationOffset] = useState(0);
   const [calibrating, setCalibrating] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [vibrationMode, setVibrationMode] = useState(false);
 
   // ----- REFS ----------------------------------------------------------------
   const rotRef = useRef(0);
@@ -192,6 +193,10 @@ export default function App() {
       northSoundPlaying.current = false;
     }
   };
+const vibrateNorth = () => {
+  lastNorthSoundTime.current = Date.now();
+  Vibration.vibrate([0,40,60,40]);
+};
 
   const playQuestionSound = async () => {
     try {
@@ -331,8 +336,13 @@ export default function App() {
       if (pulseRef.current) {
         pulseRef.current.setNativeProps({ style: { opacity: 0.4 } });
       }
-      stopSilentSound();
-      playNorth();
+      if (vibrationMode) {
+        startSilentSound();
+        vibrateNorth();
+      } else {
+        stopSilentSound();
+        playNorth();
+      }
     } else if (!northNow && north) {
       setNorth(false);
       if (pulseRef.current) {
@@ -665,6 +675,24 @@ export default function App() {
               trackColor={{ false: '#475569', true: '#3B82F6' }}
               thumbColor={questionSoundEnabled ? '#fff' : '#f4f4f4'}
               disabled={freq === 0}
+            />
+          </View>
+        </View>
+
+        {/* Vibration Mode Toggle */}
+        <View style={styles.settingBox}>
+          <View style={styles.switchRow}>
+            <View>
+              <Text style={styles.settingLabel}>Vibration Mode</Text>
+              <Text style={styles.settingDescription}>
+                Vibrate instead of sound when facing north
+              </Text>
+            </View>
+            <Switch
+              value={vibrationMode}
+              onValueChange={setVibrationMode}
+              trackColor={{ false: '#475569', true: '#3B82F6' }}
+              thumbColor={vibrationMode ? '#fff' : '#f4f4f4'}
             />
           </View>
         </View>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A React Native Expo app that provides compass functionality with background audi
 ## Features
 
 - Real-time compass with smooth rotation
-- Audio notifications when facing north
+- Audio or vibration when facing north
 - Directional audio cues with configurable frequency
 - Background audio playback (works when app is backgrounded)
 - Optional offset calibration for using the phone at an angle (including in a pocket)
@@ -97,7 +97,7 @@ eas submit --platform ios
 ## Usage
 
 1. Open app and toggle the switch to start compass
-2. Point device north to hear notification sound
+2. Point device north to feel vibration or hear a sound
 3. Configure direction sound frequency in settings
 4. App continues to work when backgrounded or when other apps are open
 


### PR DESCRIPTION
## Summary
- support vibration feedback when device faces north
- let users toggle vibration mode in settings
- document vibration option in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687920df5854832691578f9ca9991d49