### PR TITLE
Add vibration feedback mode

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react';
 import {
   StyleSheet, View, Text, TouchableOpacity,
-  Alert, AppState, Dimensions, ScrollView, Switch, Modal
+  Alert, AppState, Dimensions, ScrollView, Switch, Modal,
+  Vibration
 } from 'react-native';
 import { Audio, InterruptionModeIOS, InterruptionModeAndroid } from 'expo-av';
 import CompassHeading from 'react-native-compass-heading';
@@ -102,6 +103,7 @@ export default function App() {
   const [calibrationOffset, setCalibrationOffset] = useState(0);
   const [calibrating, setCalibrating] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [vibrateOnNorth, setVibrateOnNorth] = useState(false);
 
   // ----- REFS ----------------------------------------------------------------
   const rotRef = useRef(0);
@@ -185,11 +187,25 @@ export default function App() {
           northSoundPlaying.current = false;
         }, 300);
         await northSound.current?.replayAsync();
-        
+
       }
     } catch (error) {
       console.error('North sound error:', error);
       northSoundPlaying.current = false;
+    }
+  };
+
+  const vibrateNorth = () => {
+    Vibration.cancel();
+    Vibration.vibrate([0, 40, 60, 40]);
+  };
+
+  const triggerNorthFeedback = async () => {
+    lastNorthSoundTime.current = Date.now();
+    if (vibrateOnNorth) {
+      vibrateNorth();
+    } else {
+      await playNorth();
     }
   };
 
@@ -331,8 +347,12 @@ export default function App() {
       if (pulseRef.current) {
         pulseRef.current.setNativeProps({ style: { opacity: 0.4 } });
       }
-      stopSilentSound();
-      playNorth();
+      if (vibrateOnNorth) {
+        startSilentSound();
+      } else {
+        stopSilentSound();
+      }
+      triggerNorthFeedback();
     } else if (!northNow && north) {
       setNorth(false);
       if (pulseRef.current) {
@@ -665,6 +685,24 @@ export default function App() {
               trackColor={{ false: '#475569', true: '#3B82F6' }}
               thumbColor={questionSoundEnabled ? '#fff' : '#f4f4f4'}
               disabled={freq === 0}
+            />
+          </View>
+        </View>
+
+        {/* Vibrate on North Toggle */}
+        <View style={styles.settingBox}>
+          <View style={styles.switchRow}>
+            <View>
+              <Text style={styles.settingLabel}>Vibrate on North</Text>
+              <Text style={styles.settingDescription}>
+                Replaces the north beep with gentle vibration
+              </Text>
+            </View>
+            <Switch
+              value={vibrateOnNorth}
+              onValueChange={setVibrateOnNorth}
+              trackColor={{ false: '#475569', true: '#3B82F6' }}
+              thumbColor={vibrateOnNorth ? '#fff' : '#f4f4f4'}
             />
           </View>
         </View>

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A React Native Expo app that provides compass functionality with background audi
 
 - Real-time compass with smooth rotation
 - Audio notifications when facing north
+- Optional vibration feedback when facing north (works in background)
 - Directional audio cues with configurable frequency
 - Background audio playback (works when app is backgrounded)
 - Optional offset calibration for using the phone at an angle (including in a pocket)
@@ -97,7 +98,7 @@ eas submit --platform ios
 ## Usage
 
 1. Open app and toggle the switch to start compass
-2. Point device north to hear notification sound
+2. Point device north to hear a sound or feel vibration
 3. Configure direction sound frequency in settings
 4. App continues to work when backgrounded or when other apps are open
 


### PR DESCRIPTION
## Summary
- make phone vibrate instead of beep when facing north
- keep silent sound running in vibration mode so the app stays active in the background
- allow toggling "Vibrate on North" in settings
- update documentation to mention new vibration feature

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687920df5854832691578f9ca9991d49