### PR TITLE
Add vibration mode for north

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A React Native Expo app that provides compass functionality with background audi
 ## Features
 
 - Real-time compass with smooth rotation
-- Audio notifications when facing north
+- Audio or vibration notifications when facing north (vibration works in background)
 - Directional audio cues with configurable frequency
 - Background audio playback (works when app is backgrounded)
 - Optional offset calibration for using the phone at an angle (including in a pocket)
@@ -97,8 +97,8 @@ eas submit --platform ios
 ## Usage
 
 1. Open app and toggle the switch to start compass
-2. Point device north to hear notification sound
-3. Configure direction sound frequency in settings
+2. Point device north to hear a sound or feel a vibration
+3. Configure direction sound frequency and vibration in settings
 4. App continues to work when backgrounded or when other apps are open
 
 ## Notes
@@ -106,5 +106,7 @@ eas submit --platform ios
 - Requires iOS device with magnetometer
 - Works best when device is held flat
 - Audio will mix with other apps (doesn't interrupt music/calls)
+- Vibration works in the background thanks to a silent audio loop
+- Uses a short double-buzz pattern for a pleasant feel
 - No location permissions required
 - Complies with App Store guidelines for background audio


### PR DESCRIPTION
## Summary
- add `.gitignore`
- add vibration mode with `Vibration.vibrate`
- tweak compass logic to keep silent audio loop when using vibration
- document vibration feature in README
- refine vibration pattern and start silent sound when vibration is enabled

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687920df5854832691578f9ca9991d49