### PR TITLE
Revamp settings UI

### DIFF
--- a/App.js
+++ b/App.js
@@ -693,43 +693,36 @@ export default function App() {
       </View>
 
       {/* Settings */}
-      <View style={styles.settingsContainer}>
-        <View style={styles.settingBox}>
-          <Text style={styles.settingLabel}>🎧 Direction Sound Frequency</Text>
-          
-          <TouchableOpacity 
-            style={styles.dropdownButton} 
-            onPress={() => setShowDropdown(!showDropdown)}
-          >
-            <Text style={styles.dropdownButtonText}>{freqTxt()}</Text>
-            <Text style={styles.dropdownArrow}>{showDropdown ? '▲' : '▼'}</Text>
-          </TouchableOpacity>
-        </View>
-
-        {/* Learning Mode Toggle */}
-        <View style={styles.settingBox}>
-          <View style={styles.switchRow}>
-            <View>
-              <Text style={styles.settingLabel}>Learning Mode</Text>
-              <Text style={styles.settingDescription}>
-                Plays a cue sound 1s before direction
-              </Text>
-            </View>
-            <Switch
-              value={questionSoundEnabled}
-              onValueChange={setQuestionSoundEnabled}
-              trackColor={{ false: '#475569', true: '#3B82F6' }}
-              thumbColor={questionSoundEnabled ? '#fff' : '#f4f4f4'}
-              disabled={freq === 0}
-            />
-          </View>
-        </View>
-        
+      <View style={styles.gridContainer}>
         <TouchableOpacity
-          style={styles.advancedButton}
+          style={[styles.panel, freq > 0 && styles.panelActive]}
+          onPress={() => setShowDropdown(true)}
+        >
+          <Text style={styles.panelLabel}>Frequency</Text>
+          <Text style={styles.panelValue}>{freqTxt()}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.panel, questionSoundEnabled && styles.panelActive]}
+          onPress={() => setQuestionSoundEnabled(!questionSoundEnabled)}
+        >
+          <Text style={styles.panelLabel}>Learning</Text>
+          <Text style={styles.panelValue}>{questionSoundEnabled ? 'On' : 'Off'}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.panel, vibrationMode && styles.panelActiveGreen]}
+          onPress={() => setVibrationMode(!vibrationMode)}
+        >
+          <Text style={styles.panelLabel}>Vibrate</Text>
+          <Text style={styles.panelValue}>{vibrationMode ? 'On' : 'Off'}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.panel}
           onPress={() => setShowAdvanced(true)}
         >
-          <Text style={styles.advancedButtonText}>Advanced</Text>
+          <Text style={styles.panelLabel}>More</Text>
         </TouchableOpacity>
       </View>
 
@@ -937,9 +930,40 @@ const styles = StyleSheet.create({
     color: 'rgba(255,255,255,0.8)',
     marginTop: 8,
   },
-  settingsContainer: {
+  gridContainer: {
     width: '90%',
-    gap: 12,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    marginBottom: 10,
+  },
+  panel: {
+    width: '48%',
+    paddingVertical: 16,
+    backgroundColor: 'rgba(30,45,70,0.5)',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'rgba(148,163,184,0.3)',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  panelLabel: {
+    color: '#fff',
+    fontSize: 14,
+  },
+  panelValue: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 'bold',
+    marginTop: 4,
+  },
+  panelActive: {
+    backgroundColor: 'rgba(59,130,246,0.2)',
+    borderColor: '#3B82F6',
+  },
+  panelActiveGreen: {
+    backgroundColor: 'rgba(34,197,94,0.2)',
+    borderColor: '#22C55E',
   },
   settingBox: {
     width: '100%',
@@ -1062,19 +1086,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     color: 'rgba(255,255,255,0.7)',
     fontSize: 14,
-  },
-  advancedButton: {
-    backgroundColor: '#64748B',
-    paddingVertical: 10,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-    marginTop: 10,
-    alignItems: 'center',
-  },
-  advancedButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
   },
   closeButton: {
     backgroundColor: '#475569',


### PR DESCRIPTION
## Summary
- replace old settings layout with a simple 4‑panel grid
- toggle learning and vibration modes via grid panels
- open frequency selector and advanced options from panels
- add styles for new grid layout
- remove unused styles

## Testing
- `node --help` *(checked Node availability)*

------
https://chatgpt.com/codex/tasks/task_e_687a68617dc083269089d239cad7e59e