### PR TITLE
Improve settings layout

### DIFF
--- a/App.js
+++ b/App.js
@@ -104,7 +104,6 @@ export default function App() {
   const [questionSoundEnabled, setQuestionSoundEnabled] = useState(false);
   const [calibrationOffset, setCalibrationOffset] = useState(0);
   const [calibrating, setCalibrating] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const [vibrationMode, setVibrationMode] = useState(false);
   //const [lowPower, setLowPower] = useState(false);
 
@@ -555,6 +554,7 @@ export default function App() {
 
   return (
     <LinearGradient colors={['#0f1a2b', '#253b56']} style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
       {/* Header */}
       <View style={styles.header}>
         <Text style={styles.title}>Sonic Compass</Text>
@@ -692,45 +692,86 @@ export default function App() {
         <Text style={styles.dir}>{dirTxt(heading)}</Text>
       </View>
 
-      {/* Settings */}
-      <View style={styles.settingsContainer}>
-        <View style={styles.settingBox}>
-          <Text style={styles.settingLabel}>🎧 Direction Sound Frequency</Text>
-          
-          <TouchableOpacity 
-            style={styles.dropdownButton} 
-            onPress={() => setShowDropdown(!showDropdown)}
-          >
-            <Text style={styles.dropdownButtonText}>{freqTxt()}</Text>
-            <Text style={styles.dropdownArrow}>{showDropdown ? '▲' : '▼'}</Text>
-          </TouchableOpacity>
-        </View>
+      {/* Quick Settings Grid */}
+      <View style={styles.gridContainer}>
+        <TouchableOpacity
+          style={[styles.gridItem, freq > 0 && styles.gridItemActive]}
+          onPress={() => setShowDropdown(true)}
+        >
+          <Text style={styles.gridLabel}>Frequency</Text>
+          <Text style={styles.gridValue}>{freqTxt()}</Text>
+        </TouchableOpacity>
 
-        {/* Learning Mode Toggle */}
+        <TouchableOpacity
+          style={[styles.gridItem, questionSoundEnabled && styles.gridItemActive]}
+          onPress={() => setQuestionSoundEnabled(!questionSoundEnabled)}
+        >
+          <Text style={styles.gridLabel}>Learning</Text>
+          <Text style={styles.gridValue}>{questionSoundEnabled ? 'On' : 'Off'}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.gridItem, vibrationMode && styles.gridItemActive]}
+          onPress={() => setVibrationMode(!vibrationMode)}
+        >
+          <Text style={styles.gridLabel}>Vibration</Text>
+          <Text style={styles.gridValue}>{vibrationMode ? 'On' : 'Off'}</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Advanced Settings */}
+      <View style={styles.advancedContainer}>
+        <Text style={styles.advancedTitle}>Advanced</Text>
+
         <View style={styles.settingBox}>
+          <Text style={styles.settingLabel}>Calibrate Compass</Text>
           <View style={styles.switchRow}>
             <View>
-              <Text style={styles.settingLabel}>Learning Mode</Text>
               <Text style={styles.settingDescription}>
-                Plays a cue sound 1s before direction
+                To improve the calibration of the compass, slowly rotate your phone along all three axis multiple times.
               </Text>
             </View>
-            <Switch
-              value={questionSoundEnabled}
-              onValueChange={setQuestionSoundEnabled}
-              trackColor={{ false: '#475569', true: '#3B82F6' }}
-              thumbColor={questionSoundEnabled ? '#fff' : '#f4f4f4'}
-              disabled={freq === 0}
-            />
           </View>
         </View>
-        
-        <TouchableOpacity
-          style={styles.advancedButton}
-          onPress={() => setShowAdvanced(true)}
-        >
-          <Text style={styles.advancedButtonText}>Advanced</Text>
-        </TouchableOpacity>
+
+        <View style={styles.settingBox}>
+          <Text style={styles.settingLabel}>Add Offset</Text>
+          <View style={styles.switchRow}>
+            <View>
+              <Text style={styles.settingDescription}>
+                If you want to keep the phone in a pocket. Hold the phone in front of you, facing exactly forward; press Add Offset; then you'll have 5s to put the phone in a pocket.
+              </Text>
+              {calibrationOffset > 0 && !calibrating && (
+                <Text style={styles.settingDescriptionBold}>
+                  Offset: {calibrationOffset.toFixed(1)}°
+                </Text>
+              )}
+              {calibrating && (
+                <Text style={styles.settingDescriptionBold}>
+                  Place the phone where you'll keep it, then don't move for 5s.
+                </Text>
+              )}
+            </View>
+          </View>
+          <TouchableOpacity
+            style={[styles.calibrateButton, calibrating && styles.calibrateButtonDisabled]}
+            onPress={startCalibration}
+            disabled={calibrating}
+          >
+            <Text style={styles.calibrateButtonText}>
+              {calibrating ? 'Put the phone in a pocket...' : 'Add Offset'}
+            </Text>
+          </TouchableOpacity>
+          {!calibrating && calibrationOffset !== 0 && (
+            <TouchableOpacity
+              style={[styles.calibrateButton, styles.resetButton]}
+              onPress={resetCalibration}
+              disabled={calibrationOffset === 0}
+            >
+              <Text style={styles.calibrateButtonText}>Reset Offset</Text>
+            </TouchableOpacity>
+          )}
+        </View>
       </View>
 
       {/* Status */}
@@ -774,110 +815,7 @@ export default function App() {
           </View>
         </TouchableOpacity>
       </Modal>
-      <Modal
-        visible={showAdvanced}
-        transparent={true}
-        animationType="fade"
-        onRequestClose={() => setShowAdvanced(false)}
-      >
-        <TouchableOpacity
-          style={styles.modalOverlay}
-          activeOpacity={1}
-          onPress={() => setShowAdvanced(false)}
-        >
-          
-
-          {/* Vibration Mode Toggle */}
-          <View style={styles.modalContent}>
-            <View style={styles.settingBox}>
-              <View style={styles.switchRow}>
-                <View>
-                  <Text style={styles.settingLabel}>Vibration Mode</Text>
-                  <Text style={styles.settingDescription}>
-                    Vibrate on North.
-                  </Text>
-                </View>
-                <Switch
-                  value={vibrationMode}
-                  onValueChange={setVibrationMode}
-                  trackColor={{ false: '#475569', true: '#3B82F6' }}
-                  thumbColor={vibrationMode ? '#fff' : '#f4f4f4'}
-                />
-              </View>
-            </View>
-          </View>
-
-          
-
-          <View style={styles.modalContent}>
-            <View style={styles.settingBox}>
-              <Text style={styles.settingLabel}>Calibrate Compass</Text>
-              <View style={styles.switchRow}>
-                <View>
-                  <Text style={styles.settingDescription}>
-                    To improve the calibration of the compass, slowly rotate your phone along all three axis multiple times. 
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-
-          
-          {/* Offset Calibration */}
-          <View style={styles.modalContent}>
-            <View style={styles.settingBox}>
-              <Text style={styles.settingLabel}>Add Offset</Text>
-              <View style={styles.switchRow}>
-                <View>
-                    <Text style={styles.settingDescription}>
-                      If you want to keep the phone in a pocket. Hold the phone in front of you, facing exactly forward; press Add Offset; then you'll have 5s to put the phone in a pocket.
-                    </Text>
-                  {calibrationOffset > 0 && !calibrating && (
-                    <Text style={styles.settingDescriptionBold}>
-                      Offset: {calibrationOffset.toFixed(1)}°
-                    </Text>
-                  )}
-                  {(calibrating) && (
-                    <Text style={styles.settingDescriptionBold}>
-                      Place the phone where you'll keep it, then don't move for 5s.
-                    </Text>
-                  )}
-                </View>
-              </View>
-              <TouchableOpacity
-                style={[
-                  styles.calibrateButton,
-                  calibrating && styles.calibrateButtonDisabled,
-                ]}
-                onPress={startCalibration}
-                disabled={calibrating}
-              >
-                <Text style={styles.calibrateButtonText}>
-                  {calibrating ? 'Put the phone in a pocket...' : 'Add Offset'}
-                </Text>
-              </TouchableOpacity>
-              {!calibrating && calibrationOffset !== 0 && <TouchableOpacity
-                style={[
-                  styles.calibrateButton,
-                  styles.closeButton,
-                ]}
-                onPress={resetCalibration}
-                disabled={calibrationOffset === 0}
-              >
-                <Text style={styles.calibrateButtonText}>
-                  Reset Offset
-                </Text>
-              </TouchableOpacity> }
-            </View>
-            <TouchableOpacity
-              style={styles.closeButton}
-              onPress={() => setShowAdvanced(false)}
-            >
-              <Text style={styles.closeButtonText}>Close</Text>
-            </TouchableOpacity>
-          </View>
-        </TouchableOpacity>
-      </Modal>
+      </ScrollView>
     </LinearGradient>
   );
 }
@@ -937,10 +875,6 @@ const styles = StyleSheet.create({
     color: 'rgba(255,255,255,0.8)',
     marginTop: 8,
   },
-  settingsContainer: {
-    width: '90%',
-    gap: 12,
-  },
   settingBox: {
     width: '100%',
     padding: 15,
@@ -969,6 +903,55 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: 2,
     fontWeight: 'bold',
+  },
+  scrollContent: {
+    alignItems: 'center',
+    paddingBottom: 80,
+  },
+  gridContainer: {
+    width: '90%',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    marginTop: 10,
+  },
+  gridItem: {
+    width: '32%',
+    marginBottom: 10,
+    paddingVertical: 12,
+    backgroundColor: 'rgba(30,45,70,0.5)',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'rgba(148,163,184,0.3)',
+    alignItems: 'center',
+  },
+  gridItemActive: {
+    borderColor: '#22c55e',
+  },
+  gridLabel: {
+    color: '#fff',
+    fontSize: 14,
+  },
+  gridValue: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 4,
+  },
+  advancedContainer: {
+    width: '90%',
+    gap: 12,
+    marginTop: 20,
+  },
+  advancedTitle: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 6,
+  },
+  resetButton: {
+    backgroundColor: '#475569',
+    marginTop: 6,
   },
   dropdownButton: {
     backgroundColor: 'rgba(248,250,252,0.1)',
@@ -1062,31 +1045,5 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     color: 'rgba(255,255,255,0.7)',
     fontSize: 14,
-  },
-  advancedButton: {
-    backgroundColor: '#64748B',
-    paddingVertical: 10,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-    marginTop: 10,
-    alignItems: 'center',
-  },
-  advancedButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  closeButton: {
-    backgroundColor: '#475569',
-    paddingVertical: 10,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-    marginTop: 16,
-    alignItems: 'center',
-  },
-  closeButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
   },
 });

--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ eas submit --platform ios
 
 ## Usage
 
-1. Open app and toggle the switch to start compass
-2. Point device north to hear notification sound
-3. Configure direction sound frequency in settings
-4. App continues to work when backgrounded or when other apps are open
+1. Open the app to see the compass
+2. Use the grid at the bottom to toggle Learning and Vibration modes or tap the Frequency panel to choose a cue interval
+3. Scroll down for advanced settings like compass calibration and pocket offset
+4. Point the device north to hear notification sound
+5. App continues to work when backgrounded or when other apps are open
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- redesign settings with new grid of quick toggles
- display advanced options by scrolling instead of a separate modal
- update README usage section with new instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a6bcbe8b08326865e6afcf44d6c33