### PR TITLE
UI tweak: settings grid with scroll

### DIFF
--- a/App.js
+++ b/App.js
@@ -104,7 +104,6 @@ export default function App() {
   const [questionSoundEnabled, setQuestionSoundEnabled] = useState(false);
   const [calibrationOffset, setCalibrationOffset] = useState(0);
   const [calibrating, setCalibrating] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const [vibrationMode, setVibrationMode] = useState(false);
   //const [lowPower, setLowPower] = useState(false);
 
@@ -555,6 +554,7 @@ export default function App() {
 
   return (
     <LinearGradient colors={['#0f1a2b', '#253b56']} style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContent}>
       {/* Header */}
       <View style={styles.header}>
         <Text style={styles.title}>Sonic Compass</Text>
@@ -694,47 +694,93 @@ export default function App() {
 
       {/* Settings */}
       <View style={styles.settingsContainer}>
+        <TouchableOpacity
+          style={styles.settingPanel}
+          onPress={() => setShowDropdown(!showDropdown)}
+        >
+          <Text style={styles.settingLabel}>Frequency</Text>
+          <Text style={styles.settingValue}>{freqTxt()}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[
+            styles.settingPanel,
+            questionSoundEnabled && styles.settingPanelActive,
+          ]}
+          onPress={() => setQuestionSoundEnabled(!questionSoundEnabled)}
+        >
+          <Text style={styles.settingLabel}>Learning</Text>
+          <Text style={styles.settingValue}>
+            {questionSoundEnabled ? 'On' : 'Off'}
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[
+            styles.settingPanel,
+            vibrationMode && styles.settingPanelActive,
+          ]}
+          onPress={() => setVibrationMode(!vibrationMode)}
+        >
+          <Text style={styles.settingLabel}>Vibration</Text>
+          <Text style={styles.settingValue}>{vibrationMode ? 'On' : 'Off'}</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Extra Settings */}
+      <View style={styles.extraSettings}>
         <View style={styles.settingBox}>
-          <Text style={styles.settingLabel}>🎧 Direction Sound Frequency</Text>
-          
-          <TouchableOpacity 
-            style={styles.dropdownButton} 
-            onPress={() => setShowDropdown(!showDropdown)}
-          >
-            <Text style={styles.dropdownButtonText}>{freqTxt()}</Text>
-            <Text style={styles.dropdownArrow}>{showDropdown ? '▲' : '▼'}</Text>
-          </TouchableOpacity>
+          <Text style={styles.settingLabel}>Calibrate Compass</Text>
+          <Text style={styles.settingDescription}>
+            To improve the calibration of the compass, slowly rotate your phone
+            along all three axis multiple times.
+          </Text>
         </View>
 
-        {/* Learning Mode Toggle */}
         <View style={styles.settingBox}>
-          <View style={styles.switchRow}>
-            <View>
-              <Text style={styles.settingLabel}>Learning Mode</Text>
-              <Text style={styles.settingDescription}>
-                Plays a cue sound 1s before direction
-              </Text>
-            </View>
-            <Switch
-              value={questionSoundEnabled}
-              onValueChange={setQuestionSoundEnabled}
-              trackColor={{ false: '#475569', true: '#3B82F6' }}
-              thumbColor={questionSoundEnabled ? '#fff' : '#f4f4f4'}
-              disabled={freq === 0}
-            />
-          </View>
+          <Text style={styles.settingLabel}>Add Offset</Text>
+          <Text style={styles.settingDescription}>
+            If you want to keep the phone in a pocket. Hold the phone in front of
+            you, facing exactly forward; press Add Offset; then you'll have 5s to
+            put the phone in a pocket.
+          </Text>
+          {calibrationOffset > 0 && !calibrating && (
+            <Text style={styles.settingDescriptionBold}>
+              Offset: {calibrationOffset.toFixed(1)}°
+            </Text>
+          )}
+          {calibrating && (
+            <Text style={styles.settingDescriptionBold}>
+              Place the phone where you'll keep it, then don't move for 5s.
+            </Text>
+          )}
+          <TouchableOpacity
+            style={[
+              styles.calibrateButton,
+              calibrating && styles.calibrateButtonDisabled,
+            ]}
+            onPress={startCalibration}
+            disabled={calibrating}
+          >
+            <Text style={styles.calibrateButtonText}>
+              {calibrating ? 'Put the phone in a pocket...' : 'Add Offset'}
+            </Text>
+          </TouchableOpacity>
+          {!calibrating && calibrationOffset !== 0 && (
+            <TouchableOpacity
+              style={[styles.calibrateButton, styles.closeButton]}
+              onPress={resetCalibration}
+              disabled={calibrationOffset === 0}
+            >
+              <Text style={styles.calibrateButtonText}>Reset Offset</Text>
+            </TouchableOpacity>
+          )}
         </View>
-        
-        <TouchableOpacity
-          style={styles.advancedButton}
-          onPress={() => setShowAdvanced(true)}
-        >
-          <Text style={styles.advancedButtonText}>Advanced</Text>
-        </TouchableOpacity>
       </View>
 
       {/* Status */}
       <Text style={styles.status}>{status}</Text>
+      </ScrollView>
 
       {/* Dropdown Modal */}
       <Modal
@@ -771,110 +817,6 @@ export default function App() {
                 </TouchableOpacity>
               ))}
             </ScrollView>
-          </View>
-        </TouchableOpacity>
-      </Modal>
-      <Modal
-        visible={showAdvanced}
-        transparent={true}
-        animationType="fade"
-        onRequestClose={() => setShowAdvanced(false)}
-      >
-        <TouchableOpacity
-          style={styles.modalOverlay}
-          activeOpacity={1}
-          onPress={() => setShowAdvanced(false)}
-        >
-          
-
-          {/* Vibration Mode Toggle */}
-          <View style={styles.modalContent}>
-            <View style={styles.settingBox}>
-              <View style={styles.switchRow}>
-                <View>
-                  <Text style={styles.settingLabel}>Vibration Mode</Text>
-                  <Text style={styles.settingDescription}>
-                    Vibrate on North.
-                  </Text>
-                </View>
-                <Switch
-                  value={vibrationMode}
-                  onValueChange={setVibrationMode}
-                  trackColor={{ false: '#475569', true: '#3B82F6' }}
-                  thumbColor={vibrationMode ? '#fff' : '#f4f4f4'}
-                />
-              </View>
-            </View>
-          </View>
-
-          
-
-          <View style={styles.modalContent}>
-            <View style={styles.settingBox}>
-              <Text style={styles.settingLabel}>Calibrate Compass</Text>
-              <View style={styles.switchRow}>
-                <View>
-                  <Text style={styles.settingDescription}>
-                    To improve the calibration of the compass, slowly rotate your phone along all three axis multiple times. 
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-
-          
-          {/* Offset Calibration */}
-          <View style={styles.modalContent}>
-            <View style={styles.settingBox}>
-              <Text style={styles.settingLabel}>Add Offset</Text>
-              <View style={styles.switchRow}>
-                <View>
-                    <Text style={styles.settingDescription}>
-                      If you want to keep the phone in a pocket. Hold the phone in front of you, facing exactly forward; press Add Offset; then you'll have 5s to put the phone in a pocket.
-                    </Text>
-                  {calibrationOffset > 0 && !calibrating && (
-                    <Text style={styles.settingDescriptionBold}>
-                      Offset: {calibrationOffset.toFixed(1)}°
-                    </Text>
-                  )}
-                  {(calibrating) && (
-                    <Text style={styles.settingDescriptionBold}>
-                      Place the phone where you'll keep it, then don't move for 5s.
-                    </Text>
-                  )}
-                </View>
-              </View>
-              <TouchableOpacity
-                style={[
-                  styles.calibrateButton,
-                  calibrating && styles.calibrateButtonDisabled,
-                ]}
-                onPress={startCalibration}
-                disabled={calibrating}
-              >
-                <Text style={styles.calibrateButtonText}>
-                  {calibrating ? 'Put the phone in a pocket...' : 'Add Offset'}
-                </Text>
-              </TouchableOpacity>
-              {!calibrating && calibrationOffset !== 0 && <TouchableOpacity
-                style={[
-                  styles.calibrateButton,
-                  styles.closeButton,
-                ]}
-                onPress={resetCalibration}
-                disabled={calibrationOffset === 0}
-              >
-                <Text style={styles.calibrateButtonText}>
-                  Reset Offset
-                </Text>
-              </TouchableOpacity> }
-            </View>
-            <TouchableOpacity
-              style={styles.closeButton}
-              onPress={() => setShowAdvanced(false)}
-            >
-              <Text style={styles.closeButtonText}>Close</Text>
-            </TouchableOpacity>
           </View>
         </TouchableOpacity>
       </Modal>
@@ -937,9 +879,27 @@ const styles = StyleSheet.create({
     color: 'rgba(255,255,255,0.8)',
     marginTop: 8,
   },
+  scrollContent: {
+    alignItems: 'center',
+    paddingBottom: 80,
+  },
   settingsContainer: {
     width: '90%',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
     gap: 12,
+    marginBottom: 10,
+  },
+  settingPanel: {
+    width: '48%',
+    padding: 15,
+    backgroundColor: 'rgba(30,45,70,0.5)',
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  settingPanelActive: {
+    backgroundColor: 'rgba(34,197,94,0.4)',
   },
   settingBox: {
     width: '100%',
@@ -969,6 +929,12 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: 2,
     fontWeight: 'bold',
+  },
+  settingValue: {
+    color: '#fff',
+    fontSize: 16,
+    marginTop: 4,
+    fontWeight: '500',
   },
   dropdownButton: {
     backgroundColor: 'rgba(248,250,252,0.1)',
@@ -1055,6 +1021,12 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '600',
   },
+  extraSettings: {
+    width: '90%',
+    gap: 12,
+    marginTop: 20,
+    marginBottom: 20,
+  },
   status: {
     position: 'absolute',
     bottom: 40,
@@ -1062,19 +1034,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     color: 'rgba(255,255,255,0.7)',
     fontSize: 14,
-  },
-  advancedButton: {
-    backgroundColor: '#64748B',
-    paddingVertical: 10,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-    marginTop: 10,
-    alignItems: 'center',
-  },
-  advancedButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
   },
   closeButton: {
     backgroundColor: '#475569',


### PR DESCRIPTION
## Summary
- simplify settings layout with grid panels
- drop advanced modal and expose calibration on scroll
- add scroll container for main screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a6bcbe8b08326865e6afcf44d6c33