### PR TITLE
Refine settings layout

### DIFF
--- a/App.js
+++ b/App.js
@@ -14,7 +14,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import Svg, { Circle, Line, Text as SvgText, G, Defs, RadialGradient, Stop, Polygon } from 'react-native-svg';
 import { Buffer } from 'buffer';
 
-const { width: screenWidth } = Dimensions.get('window');
+const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
 
 ////////////////////////////////////////////////////////////////////////////////
 // 1. STATIC CONFIGURATION //////////////////////////////////////////////////////
@@ -104,7 +104,6 @@ export default function App() {
   const [questionSoundEnabled, setQuestionSoundEnabled] = useState(false);
   const [calibrationOffset, setCalibrationOffset] = useState(0);
   const [calibrating, setCalibrating] = useState(false);
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const [vibrationMode, setVibrationMode] = useState(false);
   //const [lowPower, setLowPower] = useState(false);
 
@@ -119,6 +118,7 @@ export default function App() {
   const currentHeading = useRef(0);
   const northSoundPlaying = useRef(false);
   const pulseRef = useRef(null);
+  const scrollRef = useRef(null);
   const questionTimeoutRef = useRef(null);
   const rawHeadingRef = useRef(0);
   const calibrationOffsetRef = useRef(0);
@@ -438,6 +438,7 @@ export default function App() {
   const selectFrequency = (newFreq) => {
     setFreq(newFreq);
     setShowDropdown(false);
+    Haptics.selectionAsync();
     
     // Stop everything first
     stopDirectionSoundTimer();
@@ -454,12 +455,14 @@ export default function App() {
     calibrationOffsetRef.current = 0;
     setCalibrationOffset(0);
     setStatus('Calibration reset');
+    Haptics.selectionAsync();
   };
   
   const startCalibration = () => {
     if (calibrating) return;
     setCalibrating(true);
     setStatus('Put the phone in your pocket now...');
+    Haptics.selectionAsync();
     calibrationStartRef.current = rawHeadingRef.current;
     if (calibrationTimeoutRef.current) {
       clearTimeout(calibrationTimeoutRef.current);
@@ -473,6 +476,16 @@ export default function App() {
       setCalibrating(false);
       setStatus('Added offset!');
     }, 5000);
+  };
+
+  const scrollToAdvanced = () => {
+    scrollRef.current?.scrollTo({ y: screenHeight, animated: true });
+    Haptics.selectionAsync();
+  };
+
+  const scrollToTop = () => {
+    scrollRef.current?.scrollTo({ y: 0, animated: true });
+    Haptics.selectionAsync();
   };
 
   // ----- SIDE-EFFECTS --------------------------------------------------------
@@ -555,6 +568,12 @@ export default function App() {
 
   return (
     <LinearGradient colors={['#0f1a2b', '#253b56']} style={styles.container}>
+      <ScrollView
+        ref={scrollRef}
+        pagingEnabled
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={[styles.page, { height: screenHeight }]}>
       {/* Header */}
       <View style={styles.header}>
         <Text style={styles.title}>Sonic Compass</Text>
@@ -692,51 +711,120 @@ export default function App() {
         <Text style={styles.dir}>{dirTxt(heading)}</Text>
       </View>
 
-      {/* Settings */}
-      <View style={styles.settingsContainer}>
-        <View style={styles.settingBox}>
-          <Text style={styles.settingLabel}>🎧 Direction Sound Frequency</Text>
-          
-          <TouchableOpacity 
-            style={styles.dropdownButton} 
-            onPress={() => setShowDropdown(!showDropdown)}
-          >
-            <Text style={styles.dropdownButtonText}>{freqTxt()}</Text>
-            <Text style={styles.dropdownArrow}>{showDropdown ? '▲' : '▼'}</Text>
-          </TouchableOpacity>
-        </View>
-
-        {/* Learning Mode Toggle */}
-        <View style={styles.settingBox}>
-          <View style={styles.switchRow}>
-            <View>
-              <Text style={styles.settingLabel}>Learning Mode</Text>
-              <Text style={styles.settingDescription}>
-                Plays a cue sound 1s before direction
-              </Text>
-            </View>
-            <Switch
-              value={questionSoundEnabled}
-              onValueChange={setQuestionSoundEnabled}
-              trackColor={{ false: '#475569', true: '#3B82F6' }}
-              thumbColor={questionSoundEnabled ? '#fff' : '#f4f4f4'}
-              disabled={freq === 0}
-            />
-          </View>
-        </View>
-        
+      {/* Quick Settings Grid */}
+      <View style={styles.gridContainer}>
         <TouchableOpacity
-          style={styles.advancedButton}
-          onPress={() => setShowAdvanced(true)}
+          style={[styles.gridItem, freq > 0 && styles.gridItemActive]}
+          onPress={() => {
+            setShowDropdown(true);
+            Haptics.selectionAsync();
+          }}
         >
-          <Text style={styles.advancedButtonText}>Advanced</Text>
+          <Text style={styles.gridLabel}>Frequency</Text>
+          <Text style={styles.gridValue}>{freqTxt()}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.gridItem, questionSoundEnabled && styles.gridItemActive, freq === 0 && styles.gridItemDisabled]}
+          onPress={() => {
+            if (freq === 0) return;
+            setQuestionSoundEnabled(!questionSoundEnabled);
+            Haptics.selectionAsync();
+          }}
+        >
+          <Text style={styles.gridLabel}>Learning</Text>
+          <Text style={styles.gridValue}>{questionSoundEnabled ? 'On' : 'Off'}</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.gridItem, vibrationMode && styles.gridItemActive]}
+          onPress={() => {
+            setVibrationMode(!vibrationMode);
+            Haptics.selectionAsync();
+          }}
+        >
+          <Text style={styles.gridLabel}>Vibration</Text>
+          <Text style={styles.gridValue}>{vibrationMode ? 'On' : 'Off'}</Text>
         </TouchableOpacity>
       </View>
 
-      {/* Status */}
-      <Text style={styles.status}>{status}</Text>
+      <View style={styles.gridInfo}>
+        <Text style={styles.gridInfoText}>Frequency is how often direction cues play.</Text>
+        <Text style={styles.gridInfoText}>Learning plays a short sound before each cue.</Text>
+      </View>
 
-      {/* Dropdown Modal */}
+      <TouchableOpacity style={styles.advancedToggle} onPress={scrollToAdvanced}>
+        <Text style={styles.advancedToggleText}>Advanced \u25BC</Text>
+      </TouchableOpacity>
+    </View>
+
+    <View style={[styles.page, { height: screenHeight }]}>
+      <View style={styles.advancedContainer}>
+        <Text style={styles.advancedTitle}>Advanced</Text>
+
+        <View style={styles.settingBox}>
+          <Text style={styles.settingLabel}>Calibrate Compass</Text>
+          <View style={styles.switchRow}>
+            <View>
+              <Text style={styles.settingDescription}>
+                To improve the calibration of the compass, slowly rotate your phone along all three axis multiple times.
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.settingBox}>
+          <Text style={styles.settingLabel}>Add Offset</Text>
+          <View style={styles.switchRow}>
+            <View>
+              <Text style={styles.settingDescription}>
+                If you want to keep the phone in a pocket. Hold the phone in front of you, facing exactly forward; press Add Offset; then you'll have 5s to put the phone in a pocket.
+              </Text>
+              {calibrationOffset > 0 && !calibrating && (
+                <Text style={styles.settingDescriptionBold}>
+                  Offset: {calibrationOffset.toFixed(1)}°
+                </Text>
+              )}
+              {calibrating && (
+                <Text style={styles.settingDescriptionBold}>
+                  Place the phone where you'll keep it, then don't move for 5s.
+                </Text>
+              )}
+            </View>
+          </View>
+          <TouchableOpacity
+            style={[styles.calibrateButton, calibrating && styles.calibrateButtonDisabled]}
+            onPress={() => {
+              startCalibration();
+            }}
+            disabled={calibrating}
+          >
+            <Text style={styles.calibrateButtonText}>
+              {calibrating ? 'Put the phone in a pocket...' : 'Add Offset'}
+            </Text>
+          </TouchableOpacity>
+          {!calibrating && calibrationOffset !== 0 && (
+            <TouchableOpacity
+              style={[styles.calibrateButton, styles.resetButton]}
+              onPress={() => {
+                resetCalibration();
+              }}
+              disabled={calibrationOffset === 0}
+            >
+              <Text style={styles.calibrateButtonText}>Reset Offset</Text>
+            </TouchableOpacity>
+          )}
+        </View>
+      </View>
+
+      <TouchableOpacity style={styles.advancedToggle} onPress={scrollToTop}>
+        <Text style={styles.advancedToggleText}>\u25B2 Back</Text>
+      </TouchableOpacity>
+    </View>
+
+    <Text style={styles.status}>{status}</Text>
+
+    {/* Dropdown Modal */}
       <Modal
         visible={showDropdown}
         transparent={true}
@@ -774,110 +862,7 @@ export default function App() {
           </View>
         </TouchableOpacity>
       </Modal>
-      <Modal
-        visible={showAdvanced}
-        transparent={true}
-        animationType="fade"
-        onRequestClose={() => setShowAdvanced(false)}
-      >
-        <TouchableOpacity
-          style={styles.modalOverlay}
-          activeOpacity={1}
-          onPress={() => setShowAdvanced(false)}
-        >
-          
-
-          {/* Vibration Mode Toggle */}
-          <View style={styles.modalContent}>
-            <View style={styles.settingBox}>
-              <View style={styles.switchRow}>
-                <View>
-                  <Text style={styles.settingLabel}>Vibration Mode</Text>
-                  <Text style={styles.settingDescription}>
-                    Vibrate on North.
-                  </Text>
-                </View>
-                <Switch
-                  value={vibrationMode}
-                  onValueChange={setVibrationMode}
-                  trackColor={{ false: '#475569', true: '#3B82F6' }}
-                  thumbColor={vibrationMode ? '#fff' : '#f4f4f4'}
-                />
-              </View>
-            </View>
-          </View>
-
-          
-
-          <View style={styles.modalContent}>
-            <View style={styles.settingBox}>
-              <Text style={styles.settingLabel}>Calibrate Compass</Text>
-              <View style={styles.switchRow}>
-                <View>
-                  <Text style={styles.settingDescription}>
-                    To improve the calibration of the compass, slowly rotate your phone along all three axis multiple times. 
-                  </Text>
-                </View>
-              </View>
-            </View>
-          </View>
-
-          
-          {/* Offset Calibration */}
-          <View style={styles.modalContent}>
-            <View style={styles.settingBox}>
-              <Text style={styles.settingLabel}>Add Offset</Text>
-              <View style={styles.switchRow}>
-                <View>
-                    <Text style={styles.settingDescription}>
-                      If you want to keep the phone in a pocket. Hold the phone in front of you, facing exactly forward; press Add Offset; then you'll have 5s to put the phone in a pocket.
-                    </Text>
-                  {calibrationOffset > 0 && !calibrating && (
-                    <Text style={styles.settingDescriptionBold}>
-                      Offset: {calibrationOffset.toFixed(1)}°
-                    </Text>
-                  )}
-                  {(calibrating) && (
-                    <Text style={styles.settingDescriptionBold}>
-                      Place the phone where you'll keep it, then don't move for 5s.
-                    </Text>
-                  )}
-                </View>
-              </View>
-              <TouchableOpacity
-                style={[
-                  styles.calibrateButton,
-                  calibrating && styles.calibrateButtonDisabled,
-                ]}
-                onPress={startCalibration}
-                disabled={calibrating}
-              >
-                <Text style={styles.calibrateButtonText}>
-                  {calibrating ? 'Put the phone in a pocket...' : 'Add Offset'}
-                </Text>
-              </TouchableOpacity>
-              {!calibrating && calibrationOffset !== 0 && <TouchableOpacity
-                style={[
-                  styles.calibrateButton,
-                  styles.closeButton,
-                ]}
-                onPress={resetCalibration}
-                disabled={calibrationOffset === 0}
-              >
-                <Text style={styles.calibrateButtonText}>
-                  Reset Offset
-                </Text>
-              </TouchableOpacity> }
-            </View>
-            <TouchableOpacity
-              style={styles.closeButton}
-              onPress={() => setShowAdvanced(false)}
-            >
-              <Text style={styles.closeButtonText}>Close</Text>
-            </TouchableOpacity>
-          </View>
-        </TouchableOpacity>
-      </Modal>
+      </ScrollView>
     </LinearGradient>
   );
 }
@@ -937,10 +922,6 @@ const styles = StyleSheet.create({
     color: 'rgba(255,255,255,0.8)',
     marginTop: 8,
   },
-  settingsContainer: {
-    width: '90%',
-    gap: 12,
-  },
   settingBox: {
     width: '100%',
     padding: 15,
@@ -969,6 +950,78 @@ const styles = StyleSheet.create({
     fontSize: 13,
     marginTop: 2,
     fontWeight: 'bold',
+  },
+  gridContainer: {
+    width: '90%',
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+    marginTop: 10,
+  },
+  gridItem: {
+    width: '32%',
+    marginBottom: 10,
+    paddingVertical: 12,
+    backgroundColor: 'rgba(30,45,70,0.5)',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: 'rgba(148,163,184,0.3)',
+    alignItems: 'center',
+  },
+  gridItemActive: {
+    borderColor: '#22c55e',
+  },
+  gridItemDisabled: {
+    opacity: 0.5,
+  },
+  gridLabel: {
+    color: '#fff',
+    fontSize: 14,
+  },
+  gridValue: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+    marginTop: 4,
+  },
+  advancedContainer: {
+    width: '90%',
+    gap: 12,
+    marginTop: 20,
+  },
+  advancedTitle: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 6,
+  },
+  page: {
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    paddingVertical: 20,
+  },
+  gridInfo: {
+    width: '90%',
+    marginTop: 4,
+  },
+  gridInfoText: {
+    color: 'rgba(255,255,255,0.6)',
+    fontSize: 12,
+    textAlign: 'center',
+  },
+  advancedToggle: {
+    marginTop: 16,
+    paddingVertical: 8,
+    width: '90%',
+    alignItems: 'center',
+  },
+  advancedToggleText: {
+    color: '#fff',
+    fontSize: 16,
+  },
+  resetButton: {
+    backgroundColor: '#475569',
+    marginTop: 6,
   },
   dropdownButton: {
     backgroundColor: 'rgba(248,250,252,0.1)',
@@ -1062,31 +1115,5 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     color: 'rgba(255,255,255,0.7)',
     fontSize: 14,
-  },
-  advancedButton: {
-    backgroundColor: '#64748B',
-    paddingVertical: 10,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-    marginTop: 10,
-    alignItems: 'center',
-  },
-  advancedButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  closeButton: {
-    backgroundColor: '#475569',
-    paddingVertical: 10,
-    paddingHorizontal: 20,
-    borderRadius: 8,
-    marginTop: 16,
-    alignItems: 'center',
-  },
-  closeButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
   },
 });

--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ eas submit --platform ios
 
 ## Usage
 
-1. Open app and toggle the switch to start compass
-2. Point device north to hear notification sound
-3. Configure direction sound frequency in settings
-4. App continues to work when backgrounded or when other apps are open
+1. Open the app to see the compass
+2. The bottom grid lets you pick a cue **Frequency** (how often to hear direction cues) and toggle **Learning** (preplay sound) and **Vibration**
+3. Swipe up or tap **Advanced ▼** to reveal calibration and offset options
+4. Point the device north to hear notification sound
+5. App continues to work when backgrounded or when other apps are open
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- reorganize settings into two swipeable pages
- add info text for Frequency and Learning modes
- provide haptic feedback for toggles and buttons
- update README usage instructions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a6bcbe8b08326865e6afcf44d6c33