### PR TITLE
Enable background haptic feedback on iOS

### DIFF
--- a/App.js
+++ b/App.js
@@ -13,6 +13,7 @@ import * as ScreenOrientation from 'expo-screen-orientation';
 import { LinearGradient } from 'expo-linear-gradient';
 import Svg, { Circle, Line, Text as SvgText, G, Defs, RadialGradient, Stop, Polygon } from 'react-native-svg';
 import { Buffer } from 'buffer';
+import BackgroundHaptics from "background-haptics";
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
 
@@ -145,16 +146,10 @@ export default function App() {
 
   const triggerVibration = async () => {
     try {
-      if(isBackground.current) {
-        Vibration.vibrate(200);
+      if (isBackground.current) {
+        await BackgroundHaptics.impact('heavy');
       } else {
-        //const state = await Battery.getPowerStateAsync();
-        //const low = state?.lowPowerMode;
-        //if (low) {
-        //  await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-        //} else {
-          await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
-        //}
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Heavy);
       }
     } catch (err) {
       Vibration.vibrate(200);

--- a/background-haptics/expo-module.config.json
+++ b/background-haptics/expo-module.config.json
@@ -1,0 +1,7 @@
+{
+  "name": "background-haptics",
+  "platforms": ["ios"],
+  "ios": {
+    "modules": ["BackgroundHapticsModule"]
+  }
+}

--- a/background-haptics/ios/BackgroundHaptics.podspec
+++ b/background-haptics/ios/BackgroundHaptics.podspec
@@ -1,0 +1,18 @@
+require 'json'
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = 'BackgroundHaptics'
+  s.version      = package['version']
+  s.summary      = package['description']
+  s.description  = package['description']
+  s.license      = package['license']
+  s.author       = package['author']
+  s.platforms    = { ios: '15.1' }
+  s.source       = { git: 'https://example.com/BackgroundHaptics.git' }
+  s.static_framework = true
+  s.source_files  = '**/*.{h,m,swift}'
+  s.dependency 'ExpoModulesCore'
+  s.swift_version = '5.4'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+end

--- a/background-haptics/ios/BackgroundHapticsModule.swift
+++ b/background-haptics/ios/BackgroundHapticsModule.swift
@@ -1,0 +1,24 @@
+import ExpoModulesCore
+import AudioToolbox
+
+public class BackgroundHapticsModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("BackgroundHaptics")
+
+    AsyncFunction("impact") { (style: String?) in
+      var soundID: SystemSoundID = 1519
+      if let style = style {
+        switch style {
+        case "heavy":
+          soundID = 1521
+        case "medium":
+          soundID = 1520
+        default:
+          soundID = 1519
+        }
+      }
+      AudioServicesPlaySystemSound(soundID)
+    }
+    .runOnQueue(.main)
+  }
+}

--- a/background-haptics/package.json
+++ b/background-haptics/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "background-haptics",
+  "version": "1.0.0",
+  "main": "src/index.js",
+  "types": "src/index.js",
+  "sideEffects": false,
+  "dependencies": {},
+  "peerDependencies": {
+    "expo": "*"
+  }
+}

--- a/background-haptics/src/index.js
+++ b/background-haptics/src/index.js
@@ -1,0 +1,11 @@
+import { Platform } from 'react-native';
+import BackgroundHapticsModule from './module';
+
+export function impact(style = 'medium') {
+  if (Platform.OS !== 'ios') {
+    return Promise.resolve();
+  }
+  return BackgroundHapticsModule.impact(style);
+}
+
+export default { impact };

--- a/background-haptics/src/module.js
+++ b/background-haptics/src/module.js
@@ -1,0 +1,3 @@
+import { requireNativeModule } from 'expo-modules-core';
+
+export default requireNativeModule('BackgroundHaptics');

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@react-native-async-storage/async-storage": "2.1.2",
         "@react-native-community/slider": "^4.5.7",
         "@react-native-picker/picker": "2.11.0",
+        "background-haptics": "./background-haptics",
         "base-64": "^1.0.0",
         "buffer": "^6.0.3",
         "expo": "^53.0.0",
@@ -35,6 +36,12 @@
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
+      }
+    },
+    "background-haptics": {
+      "version": "1.0.0",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -2939,6 +2946,10 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
+    },
+    "node_modules/background-haptics": {
+      "resolved": "background-haptics",
+      "link": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-native-compass-heading": "^2.0.2",
     "react-native-easy-grid": "^0.2.2",
     "react-native-reanimated": "~3.17.4",
-    "react-native-svg": "15.11.2"
+    "react-native-svg": "15.11.2",
+    "background-haptics": "./background-haptics"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
## Summary
- add a small `background-haptics` expo module that exposes `impact` using `AudioServicesPlaySystemSound`
- use `BackgroundHaptics.impact` whenever the app is backgrounded

## Testing
- `npm install`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_687e6572094883268fcc1e9aa99dfd1d