### PR TITLE
Add background iOS haptic support

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import {
   StyleSheet, View, Text, TouchableOpacity,
   Alert, AppState, Dimensions, ScrollView, Switch, Modal,
-  Vibration
+  Vibration, NativeModules
 } from 'react-native';
 import { Audio, InterruptionModeIOS, InterruptionModeAndroid } from 'expo-av';
 // import * as Battery from 'expo-battery';
@@ -15,6 +15,7 @@ import Svg, { Circle, Line, Text as SvgText, G, Defs, RadialGradient, Stop, Poly
 import { Buffer } from 'buffer';
 
 const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
+const { BackgroundHaptic } = NativeModules;
 
 ////////////////////////////////////////////////////////////////////////////////
 // 0. ADAPTIVE UI SCALING UTILITIES ///////////////////////////////////////////
@@ -146,7 +147,11 @@ export default function App() {
   const triggerVibration = async () => {
     try {
       if(isBackground.current) {
-        Vibration.vibrate(200);
+        if (BackgroundHaptic && BackgroundHaptic.trigger) {
+          BackgroundHaptic.trigger();
+        } else {
+          Vibration.vibrate(200);
+        }
       } else {
         //const state = await Battery.getPowerStateAsync();
         //const low = state?.lowPowerMode;

--- a/app.json
+++ b/app.json
@@ -59,7 +59,8 @@
             "deploymentTarget": "15.1"
           }
         }
-      ]
+      ],
+      "./plugins/withBackgroundHaptics"
     ]
   }
 }

--- a/ios/BackgroundHaptic-Bridging-Header.h
+++ b/ios/BackgroundHaptic-Bridging-Header.h
@@ -1,0 +1,1 @@
+#import <React/RCTBridgeModule.h>

--- a/ios/BackgroundHaptic.mm
+++ b/ios/BackgroundHaptic.mm
@@ -1,0 +1,7 @@
+#import <React/RCTBridgeModule.h>
+
+@interface RCT_EXTERN_MODULE(BackgroundHaptic, NSObject)
+
+RCT_EXTERN_METHOD(trigger)
+
+@end

--- a/ios/BackgroundHaptic.swift
+++ b/ios/BackgroundHaptic.swift
@@ -1,0 +1,16 @@
+import Foundation
+import AudioToolbox
+import React
+
+@objc(BackgroundHaptic)
+class BackgroundHaptic: NSObject {
+  @objc
+  func trigger() {
+    AudioServicesPlaySystemSound(SystemSoundID(1520))
+  }
+
+  @objc
+  static func requiresMainQueueSetup() -> Bool {
+    return false
+  }
+}

--- a/plugins/withBackgroundHaptics.js
+++ b/plugins/withBackgroundHaptics.js
@@ -1,0 +1,21 @@
+const { withDangerousMod, createRunOncePlugin } = require('expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+function withBackgroundHaptics(config) {
+  return withDangerousMod(config, ['ios', async (cfg) => {
+    const projectRoot = cfg.modRequest.platformProjectRoot;
+    const srcRoot = path.join(cfg.modRequest.projectRoot, 'ios');
+    const files = ['BackgroundHaptic.swift', 'BackgroundHaptic.mm', 'BackgroundHaptic-Bridging-Header.h'];
+    for (const file of files) {
+      const src = path.join(srcRoot, file);
+      const dest = path.join(projectRoot, file);
+      if (!fs.existsSync(dest)) {
+        fs.copyFileSync(src, dest);
+      }
+    }
+    return cfg;
+  }]);
+}
+
+module.exports = createRunOncePlugin(withBackgroundHaptics, 'with-background-haptics', '1.0.0');


### PR DESCRIPTION
## Summary
- implement native iOS module for background haptics
- wire up new module in JS
- add config plugin so EAS prebuild copies native code

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687e6572094883268fcc1e9aa99dfd1d